### PR TITLE
Moved number_inventory to public

### DIFF
--- a/src/storage/singletons/Numbers/index.tsx
+++ b/src/storage/singletons/Numbers/index.tsx
@@ -50,7 +50,7 @@ class NumbersStore {
   getNumbersInventoryRanges = async () => {
     try {
       const data: AxiosResponse<any> = await request({
-        route: `${configStore.config.draasInstance}/number_inventory/ranges`,
+        route: `${configStore.config.draasInstance}/public/number_inventory/ranges`,
         loaderName: "@getNumbersData",
       });
       const ranges = data.data.ranges;
@@ -123,7 +123,7 @@ class NumbersStore {
     callback?: () => void,
   ) => {
     request({
-      route: `${configStore.config.draasInstance}/number_inventory/suggestion`,
+      route: `${configStore.config.draasInstance}/public/number_inventory/suggestion`,
       payload: { params },
     })
       .then(({ data }: any) => {


### PR DESCRIPTION
We changed on the backend the URL's and added the number_inventory api's to select ranges and get a number suggestion to public. We decided that it would be better to have all endpoints that anybody can use to move behind public